### PR TITLE
Stop faulty workflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConfiguration.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConfiguration.java
@@ -50,7 +50,8 @@ public class HealingConfiguration {
     private double blockedCoefficient;
     private int maxReplicas;
     private int statsChangePercentage;
-    private int maxErrorJobPercentage;
+    private double maxErrorJobPercentage;
+    private double maxErrorInvocationPercentage;
     private int minInvocations;
 
     public static HealingConfiguration getInstance() {
@@ -70,7 +71,8 @@ public class HealingConfiguration {
             blockedCoefficient = config.getDouble(HealingConstants.LAB_BLOCKED_COEFFICIENT, 2);
             maxReplicas = config.getInt(HealingConstants.LAB_MAX_REPLICAS, 2);
             statsChangePercentage = config.getInt(HealingConstants.LAB_STATS_CHANGE_PERCENTAGE, 10);
-            maxErrorJobPercentage = config.getInt(HealingConstants.LAB_MAX_ERROR_JOB_PERCENTAGE, 60);
+            maxErrorJobPercentage = config.getDouble(HealingConstants.LAB_MAX_ERROR_JOB_PERCENTAGE, 60);
+            maxErrorInvocationPercentage = config.getDouble(HealingConstants.LAB_MAX_ERROR_INVOCATION_PERCENTAGE, 99.9);
             minInvocations = config.getInt(HealingConstants.LAB_MIN_INVOCATIONS, 100);
 
             config.setProperty(HealingConstants.LAB_SLEEP_TIME, sleepTime / 1000);
@@ -78,6 +80,7 @@ public class HealingConfiguration {
             config.setProperty(HealingConstants.LAB_MAX_REPLICAS, maxReplicas);
             config.setProperty(HealingConstants.LAB_STATS_CHANGE_PERCENTAGE, statsChangePercentage);
             config.setProperty(HealingConstants.LAB_MAX_ERROR_JOB_PERCENTAGE, maxErrorJobPercentage);
+            config.setProperty(HealingConstants.LAB_MAX_ERROR_INVOCATION_PERCENTAGE, maxErrorInvocationPercentage);
             config.setProperty(HealingConstants.LAB_MIN_INVOCATIONS, minInvocations);
 
             config.save();
@@ -103,8 +106,12 @@ public class HealingConfiguration {
         return statsChangePercentage;
     }
 
-    public int getMaxErrorJobPercentage() {
+    public double getMaxErrorJobPercentage() {
         return maxErrorJobPercentage;
+    }
+
+    public double getMaxErrorInvocationPercentage() {
+        return maxErrorInvocationPercentage;
     }
 
     public int getMinInvocations() {

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConfiguration.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConfiguration.java
@@ -50,6 +50,8 @@ public class HealingConfiguration {
     private double blockedCoefficient;
     private int maxReplicas;
     private int statsChangePercentage;
+    private int maxErrorJobPercentage;
+    private int minInvocations;
 
     public static HealingConfiguration getInstance() {
 
@@ -68,11 +70,15 @@ public class HealingConfiguration {
             blockedCoefficient = config.getDouble(HealingConstants.LAB_BLOCKED_COEFFICIENT, 2);
             maxReplicas = config.getInt(HealingConstants.LAB_MAX_REPLICAS, 2);
             statsChangePercentage = config.getInt(HealingConstants.LAB_STATS_CHANGE_PERCENTAGE, 10);
+            maxErrorJobPercentage = config.getInt(HealingConstants.LAB_MAX_ERROR_JOB_PERCENTAGE, 60);
+            minInvocations = config.getInt(HealingConstants.LAB_MIN_INVOCATIONS, 100);
 
             config.setProperty(HealingConstants.LAB_SLEEP_TIME, sleepTime / 1000);
             config.setProperty(HealingConstants.LAB_BLOCKED_COEFFICIENT, blockedCoefficient);
             config.setProperty(HealingConstants.LAB_MAX_REPLICAS, maxReplicas);
             config.setProperty(HealingConstants.LAB_STATS_CHANGE_PERCENTAGE, statsChangePercentage);
+            config.setProperty(HealingConstants.LAB_MAX_ERROR_JOB_PERCENTAGE, maxErrorJobPercentage);
+            config.setProperty(HealingConstants.LAB_MIN_INVOCATIONS, minInvocations);
 
             config.save();
 
@@ -95,5 +101,13 @@ public class HealingConfiguration {
 
     public int getStatsChangePercentage() {
         return statsChangePercentage;
+    }
+
+    public int getMaxErrorJobPercentage() {
+        return maxErrorJobPercentage;
+    }
+
+    public int getMinInvocations() {
+        return minInvocations;
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConstants.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConstants.java
@@ -46,4 +46,9 @@ public class HealingConstants {
 
     // percentage of change, 10 meaning change bigger than 10%
     public final static String LAB_STATS_CHANGE_PERCENTAGE = "plugin.healing.stats.changePercentage";
+
+    // percentage of job errors above which all jobs get killed (stop condition)
+    public final static String LAB_MAX_ERROR_JOB_PERCENTAGE = "plugin.healing.max.errorJobPercentage";
+    // minimum number of invocations per workflow in STOP condition
+    public final static String LAB_MIN_INVOCATIONS = "plugin.healing.min.invocations";
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConstants.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingConstants.java
@@ -47,8 +47,10 @@ public class HealingConstants {
     // percentage of change, 10 meaning change bigger than 10%
     public final static String LAB_STATS_CHANGE_PERCENTAGE = "plugin.healing.stats.changePercentage";
 
-    // percentage of job errors above which all jobs get killed (stop condition)
+    // percentage of job error that triggers the killing of all jobs (stop condition)
     public final static String LAB_MAX_ERROR_JOB_PERCENTAGE = "plugin.healing.max.errorJobPercentage";
+    // percentage of invocations partial error that triggers the killing of all jobs (stop condition)
+    public final static String LAB_MAX_ERROR_INVOCATION_PERCENTAGE = "plugin.healing.max.errorInvocationPercentage";
     // minimum number of invocations per workflow in STOP condition
     public final static String LAB_MIN_INVOCATIONS = "plugin.healing.min.invocations";
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingListener.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingListener.java
@@ -131,14 +131,7 @@ public class HealingListener implements ListenerPlugin {
                 commandsMap.put(job.getCommand(), cs);
             }
             if (gaswOutput.getExitCode() != GaswExitCode.SUCCESS && gaswOutput.getExitCode() != GaswExitCode.EXECUTION_CANCELED) {
-                cs.computeJobErrorRate();
-                cs.computeInvocationPartialErrorRate();
-                if (HealingConfiguration.getInstance().getMinInvocations() >= DAOFactory.getDAOFactory().getJobDAO().getInvocationsByCommand(job.getCommand()).size()
-                       //TODO add conditions on error rates
-                        ){
-                    cs.killAllJobs();
-                }
-
+                cs.updateErrorRatesAndKillDecision();
             }
         } catch (DAOException ex) {
             logger.error("[Healing] Error computing error rates", ex);

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingListener.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/HealingListener.java
@@ -122,13 +122,15 @@ public class HealingListener implements ListenerPlugin {
         Job job = null;
         try {
             logger.info("[Healing] : job " + gaswOutput.getJobID() + " finished with exit code " + gaswOutput.getExitCode());
-            job = DAOFactory.getDAOFactory().getJobDAO().getJobByID(gaswOutput.getJobID());
+            //Attention, gaswOutput.getJobID() returns the Moteur job ID in the format command-4072786226984043.jdl
+            String jobID = gaswOutput.getJobID();
+            String command = jobID.replaceAll("(-[0-9]+.jdl)$", "");
             CommandState cs;
-            if (commandsMap.containsKey(job.getCommand())) {
-                cs = commandsMap.get(job.getCommand());
+            if (commandsMap.containsKey(command)) {
+                cs = commandsMap.get(command);
             } else {
-                cs = new CommandState(job.getCommand());
-                commandsMap.put(job.getCommand(), cs);
+                cs = new CommandState(command);
+                commandsMap.put(command, cs);
             }
             if (gaswOutput.getExitCode() != GaswExitCode.SUCCESS && gaswOutput.getExitCode() != GaswExitCode.EXECUTION_CANCELED) {
                 cs.updateErrorRatesAndKillDecision();

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
@@ -55,6 +55,8 @@ public class CommandState {
     private volatile List<Long> inputTimes;
     private volatile List<Long> executionTimes;
     private volatile List<Long> outputTimes;
+    private volatile double jobErrorRate;
+    private volatile double invocationPartialErrorRate;
 
     private Map<String,Long> lastLoggedTimes;
 
@@ -66,6 +68,8 @@ public class CommandState {
         this.inputTimes = new ArrayList<Long>();
         this.executionTimes = new ArrayList<Long>();
         this.outputTimes = new ArrayList<Long>();
+        this.jobErrorRate = 0.0 ;
+        this.invocationPartialErrorRate = 0.0 ;
 
         this.lastLoggedTimes = new HashMap<>();
 
@@ -306,6 +310,30 @@ public class CommandState {
 
     public void addUploadTime(long time) {
         this.outputTimes.add(time);
+    }
+
+    public void computeJobErrorRate() throws DAOException {
+
+        this.jobErrorRate = DAOFactory.getDAOFactory().getJobDAO().getFailedByCommand(this.command).size()
+                / DAOFactory.getDAOFactory().getJobDAO().getJobsByCommand(this.command).size();
+
+    }
+
+    public void computeInvocationPartialErrorRate() throws DAOException {
+        // TODO : after further analysis, also consider jobs running for more than MAX hours when computing invocationPartialErrorRate
+        int failures = 0;
+        List<Integer> invocationIDs = DAOFactory.getDAOFactory().getJobDAO().getInvocationsByCommand(this.command);
+        for (int invocation : invocationIDs) {
+            if (DAOFactory.getDAOFactory().getJobDAO().getFailedJobsByInvocationID(invocation).size() >= 1) {
+                failures++;
+            }
+        }
+        this.invocationPartialErrorRate = failures / DAOFactory.getDAOFactory().getJobDAO().getInvocationsByCommand(this.command).size();
+    }
+
+
+    public void killAllJobs(){
+
     }
 
     /**

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
@@ -168,7 +168,7 @@ public class CommandState {
                 }
             }
             if (jobs.size() < HealingConfiguration.getInstance().getMaxReplicas()
-                    && failedJobs.size() < GaswConfiguration.getInstance().getDefaultRetryCount()
+                    && (failedJobs.size() - 1) < GaswConfiguration.getInstance().getDefaultRetryCount()
                     && bestJob != null && ((double) bestJob.getEstimation())
                     / (setupMedian + inputMedian + executionMedian + outputMedian) >= blockedCoeff) {
 

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
@@ -346,7 +346,7 @@ public class CommandState {
         computeJobErrorRate();
         computeInvocationPartialErrorRate();
         if (DAOFactory.getDAOFactory().getJobDAO().getInvocationsByCommand(this.command).size() >= HealingConfiguration.getInstance().getMinInvocations() ) {
-            if (this.jobErrorRate >= HealingConfiguration.getInstance().getMaxErrorJobPercentage() &&
+            if (this.jobErrorRate >= HealingConfiguration.getInstance().getMaxErrorJobPercentage() ||
                     this.invocationPartialErrorRate >= HealingConfiguration.getInstance().getMaxErrorInvocationPercentage()) {
                 this.killAllJobs = true;
                 logger.info("[Healing] Attention, updating killing decision to true. Nm min invocations are "+

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
@@ -321,7 +321,7 @@ public class CommandState {
 
     public void computeJobErrorRate() throws DAOException {
         JobDAO jobDAO = DAOFactory.getDAOFactory().getJobDAO();
-        this.jobErrorRate = jobDAO.getFailedByCommand(this.command).size() / jobDAO.getJobsByCommand(this.command).size() * 100;
+        this.jobErrorRate = 100.0 * jobDAO.getFailedByCommand(this.command).size() / jobDAO.getJobsByCommand(this.command).size();
         logger.info("[Healing] Updated the jobErrorRate to " + this.jobErrorRate);
 
     }
@@ -336,7 +336,7 @@ public class CommandState {
                 failures++;
             }
         }
-        this.invocationPartialErrorRate = failures / jobDAO.getInvocationsByCommand(this.command).size() * 100;
+        this.invocationPartialErrorRate = 100.0 * failures / jobDAO.getInvocationsByCommand(this.command).size();
         logger.info("[Healing] Updated the invocationPartialErrorRate to " + this.invocationPartialErrorRate);
 
     }
@@ -349,7 +349,8 @@ public class CommandState {
             if ( this.jobErrorRate >= HealingConfiguration.getInstance().getMaxErrorJobPercentage() &&
                     this.invocationPartialErrorRate >= HealingConfiguration.getInstance().getMaxErrorInvocationPercentage()) {
                 this.killAllJobs = true;
-                logger.info("[Healing] Attention, updating killing decision to true. Job error rate is "+
+                logger.info("[Healing] Attention, updating killing decision to true. Nm min invocations are "+
+                        HealingConfiguration.getInstance().getMinInvocations()+" , job error rate is "+
                         this.jobErrorRate + " and invocation error rate is "+ this.invocationPartialErrorRate);
             }
         }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/listener/healing/execution/CommandState.java
@@ -276,7 +276,7 @@ public class CommandState {
 
             while (!stop) {
                 try {
-                    if(killAllJobs){
+                    if (killAllJobs) {
                         killAllJobs();
                     } else {
                         if (outputTimes.size() > 1) {
@@ -346,7 +346,7 @@ public class CommandState {
         computeJobErrorRate();
         computeInvocationPartialErrorRate();
         if (DAOFactory.getDAOFactory().getJobDAO().getInvocationsByCommand(this.command).size() >= HealingConfiguration.getInstance().getMinInvocations() ) {
-            if ( this.jobErrorRate >= HealingConfiguration.getInstance().getMaxErrorJobPercentage() &&
+            if (this.jobErrorRate >= HealingConfiguration.getInstance().getMaxErrorJobPercentage() &&
                     this.invocationPartialErrorRate >= HealingConfiguration.getInstance().getMaxErrorInvocationPercentage()) {
                 this.killAllJobs = true;
                 logger.info("[Healing] Attention, updating killing decision to true. Nm min invocations are "+
@@ -401,7 +401,7 @@ public class CommandState {
         try {
             JobDAO jobDAO = DAOFactory.getDAOFactory().getJobDAO();
             List<Job> failedJobs = jobDAO.getFailedJobsByInvocationID(invocationID);
-            if( (failedJobs!=null) && (!failedJobs.isEmpty())) {
+            if ((failedJobs!=null) && (!failedJobs.isEmpty())) {
                 for (Job job : failedJobs) {
                     if ((job.getStatus() == GaswStatus.ERROR_HELD) || (job.getStatus() == GaswStatus.STALLED_HELD)) {
                         GaswOutput gaswOutput = new GaswOutput(job.getFileName() + ".jdl", GaswExitCode.EXECUTION_CANCELED, job.getExitMessage(),


### PR DESCRIPTION
If given error rate thresholds are reached (either for the jobs or for the invocations), kill all the jobs of that kind.